### PR TITLE
Set font height in makefont().

### DIFF
--- a/addons/BitmapFontMaker/main.gd
+++ b/addons/BitmapFontMaker/main.gd
@@ -45,6 +45,7 @@ func makefont():
 	var region : Rect2
 	var unicode
 	var btmfont = BitmapFont.new()
+	btmfont.height = chsize.y
 	var count : int
 	btmfont.add_texture(texture)
 	for ch in input:


### PR DESCRIPTION
The fonts created using this utility don't display properly due to the font's `height` property not being set.  The result is that lines of text will overlap on top of each other.  This bug isn't noticeable if you're only displaying one line of text but is very noticeable when using the font on multiple lines at once.

This change fixes this problem by adding a line in `makefont()` which sets the `height` parameter to `chsize.y`, thus ensuring that each line of the font will be the appropriate height for the characters.